### PR TITLE
Fix sample sales category replacement

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -461,7 +461,10 @@ def generate_sample_sales_data(seed: int = 42) -> pd.DataFrame:
     sales_df["order_date"] = pd.to_datetime(sales_df["order_date"])
     sales_df = normalize_sales_df(sales_df)
     # サンプル用のカテゴリ情報が失われないよう補正
-    sales_df["category"] = sales_df["category"].replace("未分類", sales_df["product_name"].map({p["name"]: p["category"] for p in sample_products}))
+    category_map = {p["name"]: p["category"] for p in sample_products}
+    mapped_categories = sales_df["product_name"].map(category_map)
+    update_mask = sales_df["category"].eq("未分類") & mapped_categories.notna()
+    sales_df.loc[update_mask, "category"] = mapped_categories[update_mask]
     return sales_df
 
 


### PR DESCRIPTION
## Summary
- prevent pandas ValueError when generating sample sales data
- map missing categories using the predefined product-to-category mapping

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d272176b708323bf9556dae4c2f299