### PR TITLE
Add automated data ingestion and validation layer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas>=2.1.0
 numpy>=1.24.0
 plotly>=5.18.0
 openpyxl>=3.1.0
+requests>=2.31.0


### PR DESCRIPTION
## Summary
- add sidebar configuration to pull marketplace sales data via API/RPA endpoints and persist retrieved frames in session state
- introduce a reusable ValidationReport pipeline that validates required sales columns, value ranges, duplicates, and channel fee integrity
- surface ingestion warnings/errors and API status in the data management tab while switching metrics/previews to use the full merged dataset
- add requests dependency for HTTP ingestion support

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d27929eda48323b6c3de248a6b0181