### PR TITLE
Enhance dashboard interactivity and profitability insights

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy>=1.24.0
 plotly>=5.18.0
 openpyxl>=3.1.0
 requests>=2.31.0
+streamlit-plotly-events>=0.0.6


### PR DESCRIPTION
## Summary
- add reusable helpers to aggregate KPIs and sales at user-selected granularities and expose period, channel, and category filters in the main dashboard
- introduce cross-highlighting sales charts using streamlit-plotly-events to synchronise channel/category selections and update comparison tables
- expand profitability analysis with richer product metrics, interactive top-product drilldown, and per-channel/product trends

## Testing
- python -m py_compile app.py data_processing.py

------
https://chatgpt.com/codex/tasks/task_e_68d2813e20f483239e548d147f93aca9