### PR TITLE
Fix KPI aggregation KeyError by returning previous active customers

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -783,6 +783,7 @@ def calculate_kpis(
         "new_customers": new_customers,
         "repeat_customers": repeat_customers,
         "cancelled_subscriptions": cancelled,
+        "previous_active_customers": prev_active,
         "marketing_cost": marketing_cost,
         "ltv": ltv_value,
         "arpu": arpu,


### PR DESCRIPTION
## Summary
- include the previous_active_customers metric in the KPI calculation output so aggregation has the expected column

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d283d438d4832383abd95a019d1864