### PR TITLE
Add Altair-based dashboard visualizations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ streamlit>=1.32.0
 pandas>=2.1.0
 numpy>=1.24.0
 plotly>=5.18.0
+altair>=5.0.0
 openpyxl>=3.1.0
 requests>=2.31.0
 streamlit-plotly-events>=0.0.6


### PR DESCRIPTION
## Summary
- introduce shared Altair theme and McKinsey-aligned color tokens for dashboard charts
- replace sales, gross profit, inventory, and cash views with interactive Altair visualizations that include tooltips, target rules, and narrative captions
- add the Altair dependency to support the new chart components

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d3faaa3d348323a21aeff5e2da4237