### PR TITLE
Refine dashboard layout and session handling

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -3,15 +3,4 @@ primaryColor = "#0B1F3B"
 backgroundColor = "#F7F8FA"
 secondaryBackgroundColor = "#FFFFFF"
 textColor = "#1A1A1A"
-secondaryTextColor = "#5A6B7A"
 font = "sans serif"
-
-[custom]
-accentColor = "#1E88E5"
-successColor = "#4CAF50"
-warningColor = "#FBC02D"
-errorColor = "#E53935"
-spacingUnit = 8
-cardRadius = 10
-cardShadow = "0 1px 4px rgba(0,0,0,0.1)"
-fontFamily = "Inter, 'Source Sans 3', sans-serif"


### PR DESCRIPTION
## Summary
- align the Streamlit page metadata with the new dashboard brief and simplify the shared theme configuration
- track recently uploaded files in session state and surface the history in the sidebar
- rebuild the KPI cards with a reusable st.metric helper and modernize the sales detail table formatting

## Testing
- python -m compileall app.py data_processing.py

------
https://chatgpt.com/codex/tasks/task_e_68d3ff6377ec8323988d81ede951575b