### PR TITLE
Fix Streamlit navigation state assignment

### DIFF
--- a/app.py
+++ b/app.py
@@ -2588,7 +2588,6 @@ def render_navigation() -> Tuple[str, str]:
 
     selected_key = label_to_key[selected_label]
     st.session_state["main_nav"] = selected_key
-    st.session_state["main_nav_display"] = selected_label
     return selected_key, NAV_LABEL_LOOKUP[selected_key]
 
 


### PR DESCRIPTION
## Summary
- prevent reassigning Streamlit session state for `main_nav_display` after radio widget selection
- rely on widget-managed session state to avoid Streamlit API exceptions during navigation rendering

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d507e3abe48323a49963937534e144