### PR TITLE
Fix Streamlit theme configuration

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,6 +1,7 @@
 [theme]
+base = "dark"
 primaryColor = "#0B1F3B"
-backgroundColor = "#F7F8FA"
-secondaryBackgroundColor = "#FFFFFF"
-textColor = "#1A1A1A"
-font = "sans serif"
+backgroundColor = "#050B18"
+secondaryBackgroundColor = "#0F1E33"
+textColor = "#F4F7FA"
+

--- a/app.py
+++ b/app.py
@@ -51,13 +51,6 @@ st.set_page_config(
     page_icon=":bar_chart:",
     layout="wide",
     initial_sidebar_state="expanded",
-    theme={
-        "base": "dark",
-        "primaryColor": "#0B1F3B",
-        "backgroundColor": "#050B18",
-        "secondaryBackgroundColor": "#0F1E33",
-        "textColor": "#F4F7FA",
-    },
 )
 
 


### PR DESCRIPTION
## Summary
- remove the unsupported theme parameter from `st.set_page_config` to prevent startup errors
- move the dark theme settings into `.streamlit/config.toml`

## Testing
- python -m py_compile app.py data_processing.py

------
https://chatgpt.com/codex/tasks/task_e_68d53f5774d883238929a911480bcf63