### PR TITLE
Clamp period filters to available date range

### DIFF
--- a/app.py
+++ b/app.py
@@ -1562,12 +1562,12 @@ def normalize_period_state_value(
     start = start_candidate or start_default
     end = end_candidate or end_default
 
-    if start < min_date:
-        start = min_date
-    if end > max_date:
-        end = max_date
+    start = max(min_date, min(max_date, start))
+    end = max(min_date, min(max_date, end))
     if start > end:
         start, end = end, start
+        start = max(min_date, min(max_date, start))
+        end = max(min_date, min(max_date, end))
 
     return start, end
 


### PR DESCRIPTION
## Summary
- clamp stored period filter dates within the currently available min/max bounds
- ensure swapping out-of-order dates keeps both endpoints inside the valid range

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d551114ac083238d6955b9f39b1ca0