### PR TITLE
Move global filters into main layout container

### DIFF
--- a/app.py
+++ b/app.py
@@ -1743,6 +1743,90 @@ def reset_filters(defaults: Dict[str, Any]) -> None:
     trigger_rerun()
 
 
+def render_global_filter_bar(
+    store_options: Sequence[str],
+    store_index: int,
+    store_state_key: str,
+    store_widget_key: str,
+    period_state_key: str,
+    period_widget_key: str,
+    min_date: date,
+    max_date: date,
+    channel_options: Sequence[str],
+    channel_state_key: str,
+    channel_widget_key: str,
+    category_options: Sequence[str],
+    category_state_key: str,
+    category_widget_key: str,
+    freq_labels: Sequence[str],
+    freq_state_key: str,
+    freq_index: int,
+    freq_widget_key: str,
+    apply_callback: Callable[[str], None],
+    default_filters: Dict[str, Any],
+) -> None:
+    """ダッシュボード上部に表示する共通フィルタバーを描画する。"""
+
+    with st.container():
+        st.markdown("### 絞り込み条件")
+        st.selectbox(
+            "店舗選択",
+            options=store_options,
+            index=store_index,
+            key=store_widget_key,
+            help="最後に選択した店舗は次回アクセス時も自動で設定されます。",
+            on_change=apply_callback,
+            args=(store_state_key,),
+        )
+        st.date_input(
+            "表示期間（開始日 / 終了日）",
+            value=st.session_state[period_state_key],
+            min_value=min_date,
+            max_value=max_date,
+            key=period_widget_key,
+            help="ダッシュボードに表示する対象期間です。開始日と終了日を指定してください。",
+            on_change=apply_callback,
+            args=(period_state_key,),
+        )
+        st.multiselect(
+            "表示するチャネル",
+            options=channel_options,
+            default=st.session_state[channel_state_key] if channel_options else [],
+            key=channel_widget_key,
+            help="チャネル選択は関連レポートでも共有されます。",
+            on_change=apply_callback,
+            args=(channel_state_key,),
+        )
+        st.multiselect(
+            "表示するカテゴリ",
+            options=category_options,
+            default=st.session_state[category_state_key] if category_options else [],
+            key=category_widget_key,
+            help="カテゴリ選択は粗利・在庫の分析タブにも共有されます。",
+            on_change=apply_callback,
+            args=(category_state_key,),
+        )
+        st.selectbox(
+            "ダッシュボード表示粒度",
+            options=freq_labels,
+            index=freq_index,
+            key=freq_widget_key,
+            help="売上やKPIの集計粒度を選べます。月次・週次・四半期などの粒度に対応しています。",
+            on_change=apply_callback,
+            args=(freq_state_key,),
+        )
+        st.caption("選択内容は変更と同時にダッシュボードへ反映されます。")
+
+        button_cols = st.columns(2)
+        with button_cols[0]:
+            if st.button("設定をリセット", key="reset_filter_button"):
+                reset_filters(default_filters)
+        with button_cols[1]:
+            if st.button("セッション状態を初期化", key="clear_session_button"):
+                st.session_state.clear()
+                trigger_rerun()
+
+
 def jump_to_section(section_key: str) -> None:
     """ナビゲーションの選択を強制的に切り替えてリロードする。"""
 
@@ -7037,64 +7121,32 @@ def main() -> None:
         update_state_from_widget(state_key)
         trigger_rerun()
 
-    st.sidebar.selectbox(
-        "店舗選択",
-        options=store_options,
-        index=store_index,
-        key=store_widget_key,
-        help="最後に選択した店舗は次回アクセス時も自動で設定されます。",
-        on_change=_apply_filter_form,
-        args=(store_state_key,),
+    render_global_filter_bar(
+        store_options=store_options,
+        store_index=store_index,
+        store_state_key=store_state_key,
+        store_widget_key=store_widget_key,
+        period_state_key=period_state_key,
+        period_widget_key=period_widget_key,
+        min_date=min_date,
+        max_date=max_date,
+        channel_options=available_channels,
+        channel_state_key=channel_state_key,
+        channel_widget_key=channel_widget_key,
+        category_options=available_categories,
+        category_state_key=category_state_key,
+        category_widget_key=category_widget_key,
+        freq_labels=freq_labels,
+        freq_state_key=freq_state_key,
+        freq_index=freq_index,
+        freq_widget_key=freq_widget_key,
+        apply_callback=_apply_filter_form,
+        default_filters=default_filters,
     )
-    st.sidebar.date_input(
-        "表示期間（開始日 / 終了日）",
-        value=st.session_state[period_state_key],
-        min_value=min_date,
-        max_value=max_date,
-        key=period_widget_key,
-        help="ダッシュボードに表示する対象期間です。開始日と終了日を指定してください。",
-        on_change=_apply_filter_form,
-        args=(period_state_key,),
-    )
-    st.sidebar.multiselect(
-        "表示するチャネル",
-        options=available_channels,
-        default=st.session_state[channel_state_key] if available_channels else [],
-        key=channel_widget_key,
-        help="チャネル選択は関連レポートでも共有されます。",
-        on_change=_apply_filter_form,
-        args=(channel_state_key,),
-    )
-    st.sidebar.multiselect(
-        "表示するカテゴリ",
-        options=available_categories,
-        default=st.session_state[category_state_key] if available_categories else [],
-        key=category_widget_key,
-        help="カテゴリ選択は粗利・在庫の分析タブにも共有されます。",
-        on_change=_apply_filter_form,
-        args=(category_state_key,),
-    )
-    st.sidebar.selectbox(
-        "ダッシュボード表示粒度",
-        options=freq_labels,
-        index=freq_index,
-        key=freq_widget_key,
-        help="売上やKPIの集計粒度を選べます。月次・週次・四半期などの粒度に対応しています。",
-        on_change=_apply_filter_form,
-        args=(freq_state_key,),
-    )
-    st.sidebar.caption("選択内容は変更と同時にダッシュボードへ反映されます。")
 
     current_period = st.session_state[period_state_key]
     selected_granularity_label = st.session_state[freq_state_key]
     selected_freq = freq_lookup[selected_granularity_label]
-
-    st.sidebar.markdown("---")
-    if st.sidebar.button("設定をリセット", key="reset_filter_button"):
-        reset_filters(default_filters)
-    if st.sidebar.button("セッション状態を初期化", key="clear_session_button"):
-        st.session_state.clear()
-        trigger_rerun()
 
     selected_store = st.session_state[store_state_key]
     selected_channels = st.session_state[channel_state_key]


### PR DESCRIPTION
## Summary
- add a reusable `render_global_filter_bar` helper to draw the global filters in the main content container
- replace the sidebar filter widgets with the new helper while keeping session state integration intact

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68dffa79001083238c2343e8383e0458