### PR TITLE
Add demand forecasting recommendations to scenario analysis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 streamlit>=1.32.0
 pandas>=2.1.0
 numpy>=1.24.0
+statsmodels>=0.14.0
 plotly>=5.18.0
 altair>=5.0.0
 openpyxl>=3.1.0


### PR DESCRIPTION
## Summary
- add ARIMA-based demand forecasting and ABC helpers to compute inventory and campaign recommendations
- surface scenario-specific recommendation card and table in the scenario comparison view with graceful fallbacks
- include statsmodels as an optional dependency for the new forecasting logic

## Testing
- python -m compileall app.py data_processing.py

------
https://chatgpt.com/codex/tasks/task_e_68dffa9098508323a2ba4e864b1b5e17