### PR TITLE
Add hoverable previews to primary navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -352,14 +352,62 @@ STATUS_PILL_DETAILS: Dict[str, Tuple[str, str]] = {
 
 
 PRIMARY_NAV_ITEMS: List[Dict[str, str]] = [
-    {"key": "dashboard", "label": "Dashboard", "icon": "📊"},
-    {"key": "sales", "label": "売上", "icon": "🛒"},
-    {"key": "gross", "label": "粗利", "icon": "💹"},
-    {"key": "inventory", "label": "在庫", "icon": "📦"},
-    {"key": "cash", "label": "資金", "icon": "💰"},
-    {"key": "kpi", "label": "KPI", "icon": "📈"},
-    {"key": "scenario", "label": "シナリオ分析", "icon": "🧮"},
-    {"key": "data", "label": "データ管理", "icon": "🗂"},
+    {
+        "key": "dashboard",
+        "label": "Dashboard",
+        "icon": "📊",
+        "description": "主要KPIとトレンドを俯瞰できる経営ダッシュボードを表示します。",
+        "preview": "docs/previews/dashboard-overview.svg",
+    },
+    {
+        "key": "sales",
+        "label": "売上",
+        "icon": "🛒",
+        "description": "チャネル別・期間別の売上推移を可視化し、成長ポイントを把握します。",
+        "preview": "docs/previews/sales-performance.svg",
+    },
+    {
+        "key": "gross",
+        "label": "粗利",
+        "icon": "💹",
+        "description": "商品別・チャネル別の粗利率を分析し、収益性を評価します。",
+        "preview": "docs/previews/gross-margin.svg",
+    },
+    {
+        "key": "inventory",
+        "label": "在庫",
+        "icon": "📦",
+        "description": "在庫回転日数や滞留リスクを確認し、適正在庫を維持します。",
+        "preview": "docs/previews/inventory-health.svg",
+    },
+    {
+        "key": "cash",
+        "label": "資金",
+        "icon": "💰",
+        "description": "資金繰りやキャッシュフロー見通しをチェックし、資金計画を支援します。",
+        "preview": "docs/previews/cash-flow.svg",
+    },
+    {
+        "key": "kpi",
+        "label": "KPI",
+        "icon": "📈",
+        "description": "コンバージョン率やLTVなど主要KPIの変化を詳細に追跡します。",
+        "preview": "docs/previews/kpi-scorecard.svg",
+    },
+    {
+        "key": "scenario",
+        "label": "シナリオ分析",
+        "icon": "🧮",
+        "description": "複数のシナリオを比較し、感度分析や計画検証を行います。",
+        "preview": "docs/previews/scenario-planning.svg",
+    },
+    {
+        "key": "data",
+        "label": "データ管理",
+        "icon": "🗂",
+        "description": "データのインポートやクリーニング状況を管理します。",
+        "preview": "docs/previews/data-workbench.svg",
+    },
 ]
 
 NAV_LABEL_LOOKUP: Dict[str, str] = {item["key"]: item["label"] for item in PRIMARY_NAV_ITEMS}
@@ -1017,12 +1065,19 @@ def inject_mckinsey_style(*, dark_mode: bool = False) -> None:
         .main-nav-item-wrapper {{
             position: relative;
             margin-bottom: 0;
+            outline: none;
+        }}
+        .main-nav-item-wrapper:focus-visible .main-nav-item,
+        .main-nav-item-wrapper:focus-within .main-nav-item {{
+            box-shadow: 0 0 0 3px rgba(37,99,235,0.35);
         }}
         .main-nav-item-wrapper > div[data-testid="stButton"] {{
             position: absolute;
             inset: 0;
             opacity: 0;
             z-index: 2;
+            width: 100%;
+            height: 100%;
         }}
         .main-nav-item-wrapper > div[data-testid="stButton"] button {{
             height: 100%;
@@ -1030,6 +1085,10 @@ def inject_mckinsey_style(*, dark_mode: bool = False) -> None:
             padding: 0;
             border: none;
             background: transparent;
+            color: transparent;
+        }}
+        .main-nav-item-wrapper > div[data-testid="stButton"] button:focus-visible {{
+            outline: none;
         }}
         .main-nav-item {{
             display: flex;
@@ -1055,6 +1114,11 @@ def inject_mckinsey_style(*, dark_mode: bool = False) -> None:
             color: var(--text-color);
             letter-spacing: 0.01em;
         }}
+        .main-nav-item-wrapper:focus-within .main-nav-item,
+        .main-nav-item-wrapper:hover .main-nav-item {{
+            transform: translateY(-2px);
+            box-shadow: 0 12px 24px rgba(15,23,42,0.14);
+        }}
         .main-nav-item:hover {{
             transform: translateY(-2px);
             box-shadow: 0 12px 24px rgba(15,23,42,0.14);
@@ -1073,6 +1137,60 @@ def inject_mckinsey_style(*, dark_mode: bool = False) -> None:
             font-size: 1.08rem;
             font-weight: 700;
             letter-spacing: 0.03em;
+        }}
+        .nav-preview-popover {{
+            position: absolute;
+            left: 50%;
+            bottom: calc(100% + 0.75rem);
+            transform: translateX(-50%) translateY(0.5rem);
+            opacity: 0;
+            visibility: hidden;
+            pointer-events: none;
+            transition: opacity 0.2s ease, transform 0.2s ease;
+            z-index: 5;
+            width: min(220px, 80vw);
+            border-radius: var(--radius-card);
+            background: #ffffff;
+            box-shadow: 0 18px 38px rgba(15,23,42,0.22);
+            border: 1px solid rgba(148,163,184,0.35);
+            padding: 0.9rem 1rem;
+        }}
+        .main-nav-item-wrapper:focus-within .nav-preview-popover,
+        .main-nav-item-wrapper:hover .nav-preview-popover {{
+            opacity: 1;
+            visibility: visible;
+            transform: translateX(-50%) translateY(0);
+        }}
+        .nav-preview-popover__preview {{
+            margin: 0 0 0.65rem;
+            border-radius: var(--radius-card);
+            overflow: hidden;
+            background: rgba(148,163,184,0.15);
+        }}
+        .nav-preview-popover__preview img {{
+            display: block;
+            width: 100%;
+            height: auto;
+        }}
+        .main-nav-item-wrapper[data-has-preview="false"] .nav-preview-popover__preview {{
+            display: none;
+        }}
+        .nav-preview-popover__description {{
+            font-size: 0.85rem;
+            color: var(--muted-text-color);
+            line-height: 1.45;
+            margin: 0;
+        }}
+        .sr-only {{
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
         }}
         .search-card input {{
             border-radius: var(--radius-input);
@@ -3580,27 +3698,62 @@ def render_navigation() -> Tuple[str, str]:
             item_key = item["key"]
             item_label = NAV_LABEL_LOOKUP[item_key]
             icon = item.get("icon", "")
+            description = item.get("description", "")
+            preview_path = item.get("preview")
             is_active = item_key == current_key
+            description_text = html.escape(description)
+            preview_html = ""
+            preview_alt = f"{item_label}のプレビューサムネイル"
+            description_id = f"main-nav-desc-{item_key}"
 
-            col.markdown("<div class='main-nav-item-wrapper'>", unsafe_allow_html=True)
+            if preview_path:
+                preview_html = """
+                <figure class="nav-preview-popover__preview">
+                    <img src="{src}" alt="{alt}" loading="lazy" />
+                </figure>
+                """.format(src=html.escape(preview_path), alt=html.escape(preview_alt))
+
+            button_label = f"{item_label} – {description}" if description else item_label
+
+            col.markdown(
+                """
+                <div class="main-nav-item-wrapper" data-has-preview="{has_preview}" title="{title}">
+                """.format(
+                    has_preview=str(bool(preview_path)).lower(),
+                    title=description_text,
+                ),
+                unsafe_allow_html=True,
+            )
+
             if col.button(
-                " ",
+                button_label,
                 key=f"main_nav_button_{item_key}",
+                help=description if description else None,
                 width="stretch",
             ):
                 selected_key = item_key
+
             col.markdown(
                 """
-                <div class="main-nav-item {active_class}" data-key="{key}">
+                <div class="main-nav-item {active_class}" data-key="{key}" aria-hidden="true">
                     <span class="main-nav-item__icon">{icon}</span>
                     <span class="main-nav-item__label">{label}</span>
                 </div>
+                <div class="nav-preview-popover" role="tooltip" aria-hidden="true">
+                    {preview}
+                    <p class="nav-preview-popover__description">{description}</p>
+                </div>
+                <span class="sr-only" id="{description_id}">{description_text}</span>
                 </div>
                 """.format(
                     active_class="is-active" if is_active else "",
                     key=html.escape(item_key),
                     icon=html.escape(icon),
                     label=html.escape(item_label),
+                    preview=preview_html,
+                    description=description_text,
+                    description_text=description_text,
+                    description_id=html.escape(description_id),
                 ),
                 unsafe_allow_html=True,
             )

--- a/docs/previews/cash-flow.svg
+++ b/docs/previews/cash-flow.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Cash flow preview</title>
+  <desc id="desc">Area chart showing cumulative cash balance</desc>
+  <rect width="320" height="180" rx="16" fill="#0F172A" opacity="0.06"/>
+  <path d="M20 140 L60 120 L100 100 L140 110 L180 80 L220 70 L260 60 L300 40 V160 H20 Z" fill="#15803D" opacity="0.35"/>
+  <polyline points="20,130 60,112 100,90 140,104 180,76 220,68 260,54 300,46" fill="none" stroke="#2563EB" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" opacity="0.6"/>
+</svg>

--- a/docs/previews/dashboard-overview.svg
+++ b/docs/previews/dashboard-overview.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Dashboard preview</title>
+  <desc id="desc">Simplified dashboard layout with widgets</desc>
+  <rect width="320" height="180" rx="16" fill="#0F172A" opacity="0.08"/>
+  <rect x="20" y="20" width="130" height="50" rx="10" fill="#2563EB" opacity="0.2"/>
+  <rect x="170" y="20" width="130" height="50" rx="10" fill="#2563EB" opacity="0.12"/>
+  <rect x="20" y="90" width="130" height="70" rx="12" fill="#15803D" opacity="0.18"/>
+  <rect x="170" y="90" width="130" height="70" rx="12" fill="#C2410C" opacity="0.16"/>
+  <path d="M34 118 h40 l20 -22 18 30 38 -48" stroke="#2563EB" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.7"/>
+</svg>

--- a/docs/previews/data-workbench.svg
+++ b/docs/previews/data-workbench.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Data workbench preview</title>
+  <desc id="desc">Table with upload indicator illustration</desc>
+  <rect width="320" height="180" rx="16" fill="#475569" opacity="0.07"/>
+  <rect x="32" y="44" width="256" height="92" rx="12" fill="#FFFFFF" opacity="0.85"/>
+  <line x1="48" y1="76" x2="272" y2="76" stroke="#0F172A" stroke-width="4" opacity="0.08"/>
+  <line x1="48" y1="100" x2="272" y2="100" stroke="#0F172A" stroke-width="4" opacity="0.08"/>
+  <circle cx="256" cy="60" r="14" fill="#2563EB" opacity="0.8"/>
+  <path d="M256 54 v12" stroke="#ffffff" stroke-width="4" stroke-linecap="round"/>
+  <path d="M250 60 h12" stroke="#ffffff" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/docs/previews/gross-margin.svg
+++ b/docs/previews/gross-margin.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Gross margin preview</title>
+  <desc id="desc">Line chart and margin badge illustration</desc>
+  <rect width="320" height="180" rx="16" fill="#15803D" opacity="0.07"/>
+  <polyline points="20,120 70,80 120,95 170,60 220,78 270,44" fill="none" stroke="#15803D" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.6"/>
+  <circle cx="236" cy="76" r="34" fill="#2563EB" opacity="0.12"/>
+  <text x="236" y="82" text-anchor="middle" font-family="'Inter', sans-serif" font-size="24" fill="#0F172A" opacity="0.7">42%</text>
+</svg>

--- a/docs/previews/inventory-health.svg
+++ b/docs/previews/inventory-health.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Inventory health preview</title>
+  <desc id="desc">Stacked cards representing inventory levels</desc>
+  <rect width="320" height="180" rx="16" fill="#475569" opacity="0.08"/>
+  <rect x="60" y="40" width="80" height="100" rx="12" fill="#2563EB" opacity="0.25"/>
+  <rect x="120" y="30" width="110" height="120" rx="14" fill="#0F172A" opacity="0.14"/>
+  <rect x="170" y="50" width="90" height="90" rx="12" fill="#15803D" opacity="0.3"/>
+  <text x="125" y="98" font-family="'Inter', sans-serif" font-size="32" font-weight="600" fill="#0F172A" opacity="0.6">85d</text>
+</svg>

--- a/docs/previews/kpi-scorecard.svg
+++ b/docs/previews/kpi-scorecard.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">KPI scorecard preview</title>
+  <desc id="desc">Summary metrics tiles representation</desc>
+  <rect width="320" height="180" rx="16" fill="#2563EB" opacity="0.05"/>
+  <rect x="36" y="36" width="100" height="60" rx="14" fill="#2563EB" opacity="0.28"/>
+  <rect x="186" y="36" width="100" height="60" rx="14" fill="#15803D" opacity="0.26"/>
+  <rect x="36" y="110" width="100" height="34" rx="10" fill="#0F172A" opacity="0.18"/>
+  <rect x="186" y="110" width="100" height="34" rx="10" fill="#C2410C" opacity="0.22"/>
+  <text x="86" y="74" text-anchor="middle" font-family="'Inter', sans-serif" font-size="22" fill="#ffffff" opacity="0.85">CVR 3.1%</text>
+  <text x="236" y="74" text-anchor="middle" font-family="'Inter', sans-serif" font-size="22" fill="#ffffff" opacity="0.85">LTV ¥62k</text>
+</svg>

--- a/docs/previews/sales-performance.svg
+++ b/docs/previews/sales-performance.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Sales performance preview</title>
+  <desc id="desc">Bar chart preview emphasising sales trends</desc>
+  <rect width="320" height="180" rx="16" fill="#2563EB" opacity="0.06"/>
+  <rect x="42" y="70" width="32" height="70" rx="6" fill="#2563EB" opacity="0.7"/>
+  <rect x="94" y="50" width="32" height="90" rx="6" fill="#2563EB" opacity="0.5"/>
+  <rect x="146" y="30" width="32" height="110" rx="6" fill="#15803D" opacity="0.6"/>
+  <rect x="198" y="58" width="32" height="82" rx="6" fill="#2563EB" opacity="0.4"/>
+  <rect x="250" y="40" width="32" height="100" rx="6" fill="#C2410C" opacity="0.45"/>
+  <polyline points="42,60 94,38 146,26 198,46 250,34" fill="none" stroke="#0F172A" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" opacity="0.45"/>
+</svg>

--- a/docs/previews/scenario-planning.svg
+++ b/docs/previews/scenario-planning.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Scenario planning preview</title>
+  <desc id="desc">Comparison chart for multiple scenarios</desc>
+  <rect width="320" height="180" rx="16" fill="#2563EB" opacity="0.07"/>
+  <polyline points="40,120 80,90 120,110 160,80 200,96 240,70" fill="none" stroke="#2563EB" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" opacity="0.55"/>
+  <polyline points="40,130 80,118 120,124 160,102 200,108 240,98" fill="none" stroke="#C2410C" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" opacity="0.6"/>
+  <polyline points="40,110 80,82 120,86 160,60 200,76 240,64" fill="none" stroke="#15803D" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" opacity="0.6"/>
+</svg>


### PR DESCRIPTION
## Summary
- add descriptions and reusable preview thumbnails to each primary navigation tab
- render accessible hover/focus popovers that surface descriptions and previews

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e0003e23e48323b4ffde038511167f